### PR TITLE
Support getting a UUID on platforms other than Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.imgscalr:imgscalr-lib:4.2'
 	implementation 'org.apache.commons:commons-math3:3.6.1'
 	implementation 'com.opencsv:opencsv:5.7.1'
+	implementation 'com.github.oshi:oshi-core:6.6.3'
 	
 	// Tests	
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/tools/sctrade/companion/domain/user/UserService.java
+++ b/src/main/java/tools/sctrade/companion/domain/user/UserService.java
@@ -1,10 +1,16 @@
 package tools.sctrade.companion.domain.user;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.util.List;
 import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.ComputerSystem;
+import oshi.hardware.HWDiskStore;
+import oshi.hardware.HardwareAbstractionLayer;
 import tools.sctrade.companion.utils.HashUtil;
 
 public class UserService {
@@ -37,38 +43,28 @@ public class UserService {
   }
 
   private String getId() {
-    String id;
+    SystemInfo si = new SystemInfo();
+    HardwareAbstractionLayer hal = si.getHardware();
+    CentralProcessor processor = hal.getProcessor();
+    ComputerSystem computerSystem = hal.getComputerSystem();
+    List<HWDiskStore> diskStores = hal.getDiskStores();
 
-    try {
-      id = getSystemUuid();
-    } catch (Exception e) {
-      logger.warn("Could not retrieve computer identifier", e);
-      UUID uuid = UUID.randomUUID();
-      id = uuid.toString();
+    // Get CPU ID
+    String processorId = processor.getProcessorIdentifier().getProcessorID();
+
+    // Get Motherboard Serial Number
+    String motherboardSerial = computerSystem.getBaseboard().getSerialNumber();
+
+    // Get Disk Serial Number (use first disk's serial number)
+    String diskSerial = "";
+    if (!diskStores.isEmpty()) {
+      diskSerial = diskStores.get(0).getSerial();  // Access first item in the list
     }
 
-    return HashUtil.hash(id);
-  }
+    // Combine hardware components into a string
+    String hardwareString = processorId + motherboardSerial + diskSerial;
 
-  private String getSystemUuid() throws Exception {
-    String system = System.getProperty("os.name").toLowerCase();
-
-    if (system.indexOf("win") >= 0) {
-      String[] cmd = {"wmic", "csproduct", "get", "UUID"};
-      Process process = Runtime.getRuntime().exec(cmd);
-      process.waitFor();
-      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-
-      String line = "";
-      StringBuilder output = new StringBuilder();
-
-      while ((line = reader.readLine()) != null) {
-        output.append(line);
-      }
-
-      return output.toString().replaceAll("\\s+", " ").strip();
-    } else {
-      throw new RuntimeException("System is not Windows");
-    }
+    // Generate hashed UUID based on the hardware components
+    return HashUtil.hash(UUID.nameUUIDFromBytes(hardwareString.getBytes()).toString());
   }
 }


### PR DESCRIPTION
Partially solves https://github.com/EtienneLamoureux/sc-trade-companion/issues/77

This should allow for a UUID to be generated on any platform supported by [Oshi](https://github.com/oshi/oshi?tab=readme-ov-file#supported-platforms)
This keeps JNA code and other funky bits out of the codebase here and just consumes the library.


In theory this library could also be used for more verbose logging, etc. 

Let me know if you'd like any changes :smiley: 

These changes would increase the jarfile size by about 2 MiB