### PR TITLE
System Tray Improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 	// GUI look and feel
 	implementation 'com.formdev:flatlaf:3.5.2'
 	implementation 'com.formdev:flatlaf-intellij-themes:3.5.2'
+
+	// System tray (cross-platform replacement for AWT SystemTray)
+	implementation 'com.dorkbox:SystemTray:4.4'
 	
 	// Computer vision
 	implementation 'org.openpnp:opencv:4.9.0-0'

--- a/src/main/java/tools/sctrade/companion/CompanionApplication.java
+++ b/src/main/java/tools/sctrade/companion/CompanionApplication.java
@@ -1,6 +1,5 @@
 package tools.sctrade.companion;
 
-import java.awt.AWTException;
 import java.awt.EventQueue;
 import org.jnativehook.GlobalScreen;
 import org.jnativehook.NativeHookException;
@@ -21,7 +20,7 @@ public class CompanionApplication {
   private static final Logger logger = LoggerFactory.getLogger(CompanionApplication.class);
 
   @Autowired
-  public CompanionApplication(CompanionGui gui) throws AWTException {
+  public CompanionApplication(CompanionGui gui) {
     gui.initialize();
   }
 

--- a/src/main/java/tools/sctrade/companion/gui/CompanionGui.java
+++ b/src/main/java/tools/sctrade/companion/gui/CompanionGui.java
@@ -2,12 +2,8 @@ package tools.sctrade.companion.gui;
 
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.intellijthemes.FlatArcDarkOrangeIJTheme;
-import java.awt.AWTException;
+import dorkbox.systemTray.SystemTray;
 import java.awt.Image;
-import java.awt.MenuItem;
-import java.awt.PopupMenu;
-import java.awt.SystemTray;
-import java.awt.TrayIcon;
 import java.util.Arrays;
 import java.util.Locale;
 import javax.swing.JFrame;
@@ -54,10 +50,8 @@ public class CompanionGui extends JFrame implements NotificationRepository {
 
   /**
    * Initializes the companion GUI.
-   *
-   * @throws AWTException If the system tray is not supported.
    */
-  public void initialize() throws AWTException {
+  public void initialize() {
     setLookAndFeel();
     setIconImages();
 
@@ -127,38 +121,25 @@ public class CompanionGui extends JFrame implements NotificationRepository {
     add(tabbedPane);
   }
 
-  private void setupTray() throws AWTException {
-    if (SystemTray.isSupported()) {
-      setDefaultCloseOperation(HIDE_ON_CLOSE);
+  private void setupTray() {
+    SystemTray systemTray = SystemTray.get(LocalizationUtil.get("applicationTitle"));
 
-      PopupMenu popupMenu = new PopupMenu();
-      popupMenu.add(buildOpenMenuItem());
-      popupMenu.add(buildExitMenuItem());
-
-      TrayIcon trayIcon = new TrayIcon(getIcon("icon16"));
-      trayIcon.setPopupMenu(popupMenu);
-      trayIcon.setImageAutoSize(true);
-      trayIcon.setToolTip(LocalizationUtil.get("applicationTitle"));
-
-      SystemTray systemTray = SystemTray.getSystemTray();
-      systemTray.add(trayIcon);
+    if (systemTray == null) {
+      setDefaultCloseOperation(EXIT_ON_CLOSE);
+      return;
     }
 
-    setDefaultCloseOperation(EXIT_ON_CLOSE);
-  }
+    setDefaultCloseOperation(HIDE_ON_CLOSE);
+    systemTray.setImage(getIcon("icon128"));
 
-  private MenuItem buildOpenMenuItem() {
-    MenuItem openMenuItem = new MenuItem(LocalizationUtil.get("menuItemOpen"));
-    openMenuItem.addActionListener(e -> setVisible(true));
+    systemTray.getMenu().add(new dorkbox.systemTray.MenuItem(LocalizationUtil.get("menuItemOpen"),
+        e -> setVisible(true)));
 
-    return openMenuItem;
-  }
-
-  private MenuItem buildExitMenuItem() {
-    MenuItem exitMenuItem = new MenuItem(LocalizationUtil.get("menuItemExit"));
-    exitMenuItem.addActionListener(e -> System.exit(0));
-
-    return exitMenuItem;
+    systemTray.getMenu()
+        .add(new dorkbox.systemTray.MenuItem(LocalizationUtil.get("menuItemExit"), e -> {
+          systemTray.shutdown();
+          System.exit(0);
+        }));
   }
 
   private Image getIcon(String name) {


### PR DESCRIPTION
This PR should fix system trays on Linux (in various desktop environments), as well as improve the look of them on Windows.

On Linux, the tray icon doesn't have a transparent background and cannot be interacted with. So if you click on "Send to tray" the application is hidden indefinitely and has to be killed manually.

I make use of [dorkbox/SystemTray](https://github.com/dorkbox/SystemTray) for this, it allows for native look and feel on many platforms, and on Windows follows the look and feel of the application.

Let me know if you'd like any changes :)