### PR TITLE
Fix Taking Screenshots on Wayland

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 	implementation 'net.java.dev.jna:jna:5.15.0'
 	implementation 'net.java.dev.jna:jna-platform:5.15.0'
 
+	// D-Bus (Wayland screenshot portal)
+	implementation 'com.github.hypfvieh:dbus-java-core:5.2.0'
+	implementation 'com.github.hypfvieh:dbus-java-transport-native-unixsocket:5.2.0'
+
 	// Utils
 	implementation 'org.imgscalr:imgscalr-lib:4.2'
 	implementation 'org.apache.commons:commons-math3:3.6.1'

--- a/src/main/java/tools/sctrade/companion/input/ScreenPrinter.java
+++ b/src/main/java/tools/sctrade/companion/input/ScreenPrinter.java
@@ -1,6 +1,5 @@
 package tools.sctrade.companion.input;
 
-import java.awt.Robot;
 import java.awt.image.BufferedImage;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -18,6 +17,7 @@ import tools.sctrade.companion.domain.setting.SettingRepository;
 import tools.sctrade.companion.utils.AsynchronousProcessor;
 import tools.sctrade.companion.utils.GraphicsDeviceUtil;
 import tools.sctrade.companion.utils.LocalizationUtil;
+import tools.sctrade.companion.utils.ScreenshotUtil;
 import tools.sctrade.companion.utils.SoundUtil;
 
 /**
@@ -80,8 +80,7 @@ public class ScreenPrinter implements Runnable {
       soundPlayer.play(CAMERA_SHUTTER);
       var monitor = GraphicsDeviceUtil
           .get(settings.get(Setting.STAR_CITIZEN_MONITOR, GraphicsDeviceUtil.getPrimaryId()));
-      var screenRectangle = monitor.getDefaultConfiguration().getBounds();
-      var screenCapture = postProcess(new Robot(monitor).createScreenCapture(screenRectangle));
+      var screenCapture = postProcess(ScreenshotUtil.capture(monitor));
       logger.debug("Printed screen");
 
       logger.debug("Calling image processors...");

--- a/src/main/java/tools/sctrade/companion/utils/DbusScreenshot.java
+++ b/src/main/java/tools/sctrade/companion/utils/DbusScreenshot.java
@@ -1,0 +1,157 @@
+package tools.sctrade.companion.utils;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TransferQueue;
+import javax.imageio.ImageIO;
+import org.freedesktop.dbus.DBusMatchRule;
+import org.freedesktop.dbus.connections.impl.DBusConnection;
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder;
+import org.freedesktop.dbus.exceptions.DBusException;
+import org.freedesktop.dbus.interfaces.DBusSigHandler;
+import org.freedesktop.dbus.messages.DBusSignal;
+import org.freedesktop.dbus.types.UInt32;
+import org.freedesktop.dbus.types.Variant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Facade for taking screenshots via the XDG Desktop Portal D-Bus API. This is the standard
+ * mechanism for screen capture on Wayland compositors, where {@link java.awt.Robot} does not have
+ * direct access to the display.
+ *
+ * <p>
+ * The portal's {@code interactive} option is set to {@code false}, requesting a non-interactive
+ * capture. Most compositors (KDE, wlroots) honour this; GNOME may still show a dialog.
+ */
+class DbusScreenshot {
+  private static final Logger logger = LoggerFactory.getLogger(DbusScreenshot.class);
+
+  private static final String PORTAL_BUS_NAME = "org.freedesktop.portal.Desktop";
+  private static final String PORTAL_OBJECT_PATH = "/org/freedesktop/portal/desktop";
+  private static final long SCREENSHOT_TIMEOUT_SECONDS = 30;
+
+  private DbusScreenshot() {
+    // Utility class
+  }
+
+  /**
+   * Takes a screenshot via the XDG Desktop Portal.
+   *
+   * @return the captured image
+   * @throws ScreenshotException if the screenshot could not be taken
+   */
+  static BufferedImage capture() {
+    String token = UUID.randomUUID().toString().replace("-", "");
+
+    try {
+      DBusConnection bus = DBusConnectionBuilder.forSessionBus().build();
+      try {
+        return captureViaPortal(bus, token);
+      } finally {
+        bus.disconnect();
+      }
+    } catch (DBusException e) {
+      throw new ScreenshotException("Failed to connect to session D-Bus", e);
+    }
+  }
+
+  private static BufferedImage captureViaPortal(DBusConnection bus, String token)
+      throws DBusException {
+    String sender = bus.getUniqueName().substring(1).replace('.', '_');
+    String expectedPath =
+        String.format("/org/freedesktop/portal/desktop/request/%s/%s", sender, token);
+
+    TransferQueue<Optional<BufferedImage>> queue = new LinkedTransferQueue<>();
+
+    DBusMatchRule matchRule =
+        new DBusMatchRule("signal", "org.freedesktop.portal.Request", "Response");
+
+    DBusSigHandler<DBusSignal> handler = signal -> {
+      if (!expectedPath.equals(signal.getPath())) {
+        return;
+      }
+      handleResponse(signal, queue, matchRule, bus);
+    };
+
+    bus.addGenericSigHandler(matchRule, handler);
+
+    try {
+      ScreenshotPortal portal =
+          bus.getRemoteObject(PORTAL_BUS_NAME, PORTAL_OBJECT_PATH, ScreenshotPortal.class);
+
+      Map<String, Variant<?>> options = new HashMap<>();
+      options.put("interactive", new Variant<>(Boolean.FALSE));
+      options.put("handle_token", new Variant<>(token));
+
+      portal.Screenshot("", options);
+
+      Optional<BufferedImage> result = queue.poll(SCREENSHOT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      if (result == null) {
+        throw new ScreenshotException("Screenshot timed out after " + SCREENSHOT_TIMEOUT_SECONDS
+            + " seconds waiting for portal response");
+      }
+      return result.orElseThrow(() -> new ScreenshotException("Portal returned an error response"));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ScreenshotException("Screenshot interrupted", e);
+    } finally {
+      bus.removeGenericSigHandler(matchRule, handler);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void handleResponse(DBusSignal signal,
+      TransferQueue<Optional<BufferedImage>> queue, DBusMatchRule matchRule, DBusConnection bus) {
+    try {
+      Object[] params = signal.getParameters();
+      UInt32 response = (UInt32) params[0];
+      LinkedHashMap<String, Variant<?>> results = (LinkedHashMap<String, Variant<?>>) params[1];
+
+      if (response.intValue() != 0) {
+        logger.error("Portal screenshot failed with response code: {}", response);
+        queue.add(Optional.empty());
+        return;
+      }
+
+      Variant<?> uriVariant = results.get("uri");
+      String uri = (String) uriVariant.getValue();
+      logger.debug("Screenshot URI: {}", uri);
+
+      BufferedImage image = ImageIO.read(URI.create(uri).toURL());
+      queue.add(Optional.ofNullable(image));
+
+      // Clean up the temporary file created by the portal.
+      Path tempFile = Path.of(URI.create(uri));
+      if (Files.deleteIfExists(tempFile)) {
+        logger.debug("Deleted portal temp file: {}", tempFile);
+      }
+    } catch (IOException | DBusException e) {
+      logger.error("Error reading screenshot from portal", e);
+      queue.add(Optional.empty());
+    }
+  }
+
+  /**
+   * Exception thrown when a screenshot cannot be taken via the D-Bus portal.
+   */
+  static class ScreenshotException extends RuntimeException {
+    ScreenshotException(String message) {
+      super(message);
+    }
+
+    ScreenshotException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/src/main/java/tools/sctrade/companion/utils/ImageUtil.java
+++ b/src/main/java/tools/sctrade/companion/utils/ImageUtil.java
@@ -393,6 +393,7 @@ public class ImageUtil {
    *      "https://answers.opencv.org/question/28348/converting-bufferedimage-to-mat-in-java/">Source</a>
    */
   public static Mat toMat(BufferedImage image) throws IOException {
+    image = removeAlphaChannel(image);
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     ImageIO.write(image, "jpg", byteArrayOutputStream);
     byteArrayOutputStream.flush();

--- a/src/main/java/tools/sctrade/companion/utils/ImageUtil.java
+++ b/src/main/java/tools/sctrade/companion/utils/ImageUtil.java
@@ -451,7 +451,25 @@ public class ImageUtil {
     Files.createDirectories(path.getParent());
     File imageFile = new File(path.toString());
     String format = path.toString().substring(path.toString().lastIndexOf(".") + 1);
+
+    // JPEG does not support alpha channels. If the image has one (e.g. from the XDG Desktop
+    // Portal on Wayland), strip it by drawing onto an opaque RGB image.
+    if ("jpg".equalsIgnoreCase(format) || "jpeg".equalsIgnoreCase(format)) {
+      image = removeAlphaChannel(image);
+    }
+
     ImageIO.write(image, format, imageFile);
+  }
+
+  private static BufferedImage removeAlphaChannel(BufferedImage image) {
+    if (!image.getColorModel().hasAlpha()) {
+      return image;
+    }
+
+    BufferedImage rgb =
+        new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_RGB);
+    rgb.createGraphics().drawImage(image, 0, 0, null);
+    return rgb;
   }
 
   /**

--- a/src/main/java/tools/sctrade/companion/utils/ScreenshotPortal.java
+++ b/src/main/java/tools/sctrade/companion/utils/ScreenshotPortal.java
@@ -1,0 +1,28 @@
+package tools.sctrade.companion.utils;
+
+import java.util.Map;
+import org.freedesktop.dbus.DBusPath;
+import org.freedesktop.dbus.annotations.DBusInterfaceName;
+import org.freedesktop.dbus.interfaces.DBusInterface;
+import org.freedesktop.dbus.types.Variant;
+
+/**
+ * D-Bus interface binding for the XDG Desktop Portal Screenshot API.
+ *
+ * @see <a href=
+ *      "https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Screenshot.html">XDG
+ *      Desktop Portal - Screenshot</a>
+ */
+@DBusInterfaceName("org.freedesktop.portal.Screenshot")
+interface ScreenshotPortal extends DBusInterface {
+
+  /**
+   * Takes a screenshot of the current screen.
+   *
+   * @param parentWindow identifier for the application window (empty string for none)
+   * @param options a map of options; notable keys include {@code interactive} (boolean) and
+   *        {@code handle_token} (string)
+   * @return a D-Bus object path for the portal request
+   */
+  DBusPath Screenshot(String parentWindow, Map<String, Variant<?>> options);
+}

--- a/src/main/java/tools/sctrade/companion/utils/ScreenshotUtil.java
+++ b/src/main/java/tools/sctrade/companion/utils/ScreenshotUtil.java
@@ -2,14 +2,16 @@ package tools.sctrade.companion.utils;
 
 import java.awt.AWTException;
 import java.awt.GraphicsDevice;
+import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Utility for taking screenshots. On Wayland, uses the XDG Desktop Portal via D-Bus. On X11 and
- * Windows, uses {@link Robot} with the specified monitor.
+ * Utility for taking screenshots. On Wayland, uses the XDG Desktop Portal via D-Bus and crops the
+ * result to the requested monitor's bounds. On X11 and Windows, uses {@link Robot} with the
+ * specified monitor.
  */
 public class ScreenshotUtil {
   private static final Logger logger = LoggerFactory.getLogger(ScreenshotUtil.class);
@@ -19,16 +21,16 @@ public class ScreenshotUtil {
   }
 
   /**
-   * Takes a screenshot of the specified monitor. On Wayland, the monitor parameter is ignored
-   * because the XDG Desktop Portal captures the entire screen.
+   * Takes a screenshot of the specified monitor. On Wayland, the XDG Desktop Portal captures all
+   * monitors, so the result is cropped to the requested monitor's bounds.
    *
-   * @param monitor the graphics device to capture (used on X11/Windows only)
+   * @param monitor the graphics device to capture
    * @return the captured image
    * @throws AWTException if the Robot cannot be created (X11/Windows only)
    */
   public static BufferedImage capture(GraphicsDevice monitor) throws AWTException {
     if (isWayland()) {
-      return captureWayland();
+      return captureWayland(monitor);
     }
     return captureRobot(monitor);
   }
@@ -37,14 +39,15 @@ public class ScreenshotUtil {
     return "wayland".equalsIgnoreCase(System.getenv("XDG_SESSION_TYPE"));
   }
 
-  private static BufferedImage captureWayland() {
+  private static BufferedImage captureWayland(GraphicsDevice monitor) {
     logger.debug("Taking screenshot via XDG Desktop Portal (Wayland)");
     try {
-      return DbusScreenshot.capture();
+      BufferedImage fullCapture = DbusScreenshot.capture();
+      return cropToMonitor(fullCapture, monitor);
     } catch (DbusScreenshot.ScreenshotException e) {
       logger.error("D-Bus screenshot failed, falling back to Robot", e);
       try {
-        return captureRobot(GraphicsDeviceUtil.getPrimary());
+        return captureRobot(monitor);
       } catch (AWTException ex) {
         throw new IllegalStateException("Both D-Bus and Robot screenshot methods failed", ex);
       }
@@ -55,5 +58,25 @@ public class ScreenshotUtil {
     logger.debug("Taking screenshot via Robot (monitor: {})", monitor.getIDstring());
     var screenRectangle = monitor.getDefaultConfiguration().getBounds();
     return new Robot(monitor).createScreenCapture(screenRectangle);
+  }
+
+  /**
+   * Crops a full-desktop screenshot to the bounds of the specified monitor. If the monitor bounds
+   * fall outside the image (e.g. single-monitor setup), the original image is returned.
+   */
+  private static BufferedImage cropToMonitor(BufferedImage fullCapture, GraphicsDevice monitor) {
+    Rectangle bounds = monitor.getDefaultConfiguration().getBounds();
+    int x = Math.max(0, bounds.x);
+    int y = Math.max(0, bounds.y);
+    int width = Math.min(bounds.width, fullCapture.getWidth() - x);
+    int height = Math.min(bounds.height, fullCapture.getHeight() - y);
+
+    if (x == 0 && y == 0 && width == fullCapture.getWidth() && height == fullCapture.getHeight()) {
+      return fullCapture;
+    }
+
+    logger.debug("Cropping portal screenshot to monitor bounds: {}x{} at ({},{})", width, height, x,
+        y);
+    return fullCapture.getSubimage(x, y, width, height);
   }
 }

--- a/src/main/java/tools/sctrade/companion/utils/ScreenshotUtil.java
+++ b/src/main/java/tools/sctrade/companion/utils/ScreenshotUtil.java
@@ -1,0 +1,59 @@
+package tools.sctrade.companion.utils;
+
+import java.awt.AWTException;
+import java.awt.GraphicsDevice;
+import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility for taking screenshots. On Wayland, uses the XDG Desktop Portal via D-Bus. On X11 and
+ * Windows, uses {@link Robot} with the specified monitor.
+ */
+public class ScreenshotUtil {
+  private static final Logger logger = LoggerFactory.getLogger(ScreenshotUtil.class);
+
+  private ScreenshotUtil() {
+    // Utility class
+  }
+
+  /**
+   * Takes a screenshot of the specified monitor. On Wayland, the monitor parameter is ignored
+   * because the XDG Desktop Portal captures the entire screen.
+   *
+   * @param monitor the graphics device to capture (used on X11/Windows only)
+   * @return the captured image
+   * @throws AWTException if the Robot cannot be created (X11/Windows only)
+   */
+  public static BufferedImage capture(GraphicsDevice monitor) throws AWTException {
+    if (isWayland()) {
+      return captureWayland();
+    }
+    return captureRobot(monitor);
+  }
+
+  private static boolean isWayland() {
+    return "wayland".equalsIgnoreCase(System.getenv("XDG_SESSION_TYPE"));
+  }
+
+  private static BufferedImage captureWayland() {
+    logger.debug("Taking screenshot via XDG Desktop Portal (Wayland)");
+    try {
+      return DbusScreenshot.capture();
+    } catch (DbusScreenshot.ScreenshotException e) {
+      logger.error("D-Bus screenshot failed, falling back to Robot", e);
+      try {
+        return captureRobot(GraphicsDeviceUtil.getPrimary());
+      } catch (AWTException ex) {
+        throw new IllegalStateException("Both D-Bus and Robot screenshot methods failed", ex);
+      }
+    }
+  }
+
+  private static BufferedImage captureRobot(GraphicsDevice monitor) throws AWTException {
+    logger.debug("Taking screenshot via Robot (monitor: {})", monitor.getIDstring());
+    var screenRectangle = monitor.getDefaultConfiguration().getBounds();
+    return new Robot(monitor).createScreenCapture(screenRectangle);
+  }
+}


### PR DESCRIPTION
This PR implements a new "ScreenShotUtil" class that implements a CreateScreenShot method that will take a screenshot in the typical way using a `java.awt.Robot` on every desktop platform short of Wayland, this returns a `BufferedImage`, as expected.

Due to some bugs with how Wayland screenshots are handled in Java proper: https://bugs.openjdk.org/browse/JDK-8269245

We have to call the desktop bus (dbus) to request for the compositor to take a screenshot.

The screenshot is taken as a PNG image and dbus will tell us where that image is. That image is ingested as a `BufferedImage` and the PNG we took is deleted from the system. The `BufferedImage` is returned, which is what a Robot would normally do.

I also ran into a fun edge case where writing a `BufferedImage` with an alpha channel (like one we might get when reading a PNG) to a JPG silently fails, which causes the `my-images/` folder to not be populated as expected. 

I wrote a small helper method to strip out the alpha channel to avoid this:
https://github.com/EtienneLamoureux/sc-trade-companion/blob/f714efbf6838c5d75470611c25b4fef356c97469/src/main/java/tools/sctrade/companion/utils/ImageUtil.java#L257-L262

This PR pulls in the [`dbus-java`](https://github.com/hypfvieh/dbus-java?tab=readme-ov-file) library, which allows us to interface with dbus directly instead of talking to a potentially missing executable, which is the most portable way to do this.

This change adds approx 1MiB to the final jarfile.