### PR TITLE
Improve cropping for ultrawide monitor support in OCR

### DIFF
--- a/src/main/java/tools/sctrade/companion/domain/commodity/CommodityLocationTesseractOcr.java
+++ b/src/main/java/tools/sctrade/companion/domain/commodity/CommodityLocationTesseractOcr.java
@@ -43,7 +43,35 @@ public class CommodityLocationTesseractOcr extends TesseractOcr {
   }
 
   private BufferedImage keepTopLeftCorner(BufferedImage image) {
-    return ImageUtil.crop(image,
-        new Rectangle(0, 0, (image.getWidth() / 2), (image.getHeight() / 3)));
+    Rectangle locationRegion = calculateLocationRegion(image);
+    return ImageUtil.crop(image, locationRegion);
+  }
+
+  /**
+   * Calculates the region containing the location dropdown based on aspect ratio. Uses conservative
+   * wide crops for ultrawide monitors to handle viewing angle variance.
+   *
+   * @param image The source image
+   * @return Rectangle defining the region to crop
+   */
+  private Rectangle calculateLocationRegion(BufferedImage image) {
+    int width = image.getWidth();
+    int height = image.getHeight();
+    double aspectRatio = (double) width / height;
+
+    // Super ultrawide (32:9, ratio > 3.0)
+    if (aspectRatio > 3.0) {
+      // Crop from 0% to 70% width, top 40% height
+      return new Rectangle(0, 0, (int) (width * 0.70), (int) (height * 0.40));
+    }
+
+    // Ultrawide (21:9, ratio > 2.0)
+    if (aspectRatio > 2.0) {
+      // Crop from 0% to 75% width, top 40% height
+      return new Rectangle(0, 0, (int) (width * 0.75), (int) (height * 0.40));
+    }
+
+    // Standard/widescreen - original behavior
+    return new Rectangle(0, 0, width / 2, height / 3);
   }
 }


### PR DESCRIPTION
Refactored cropping logic in CommodityListingsTesseractOcr and CommodityLocationTesseractOcr to dynamically adjust crop regions based on image aspect ratio. This enhances OCR accuracy on ultrawide and super ultrawide monitors by using more conservative crops to account for viewing angle variance.

Tested and working with 0 failures